### PR TITLE
Counters ending in `_total` and timestamps are not interpreted as delta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus_wireguard_exporter"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name           = "prometheus_wireguard_exporter"
-version        = "1.2.1"
+version        = "2.0.0"
 authors        = ["Francesco Cogno <francesco.cogno@outlook.com>"]
 description    = "Prometheus WireGuard Exporter"
 edition        = "2018"


### PR DESCRIPTION
Closes [https://github.com/MindFlavor/prometheus_wireguard_exporter/issues/3](https://github.com/MindFlavor/prometheus_wireguard_exporter/issues/3) and [https://github.com/MindFlavor/prometheus_wireguard_exporter/issues/2](https://github.com/MindFlavor/prometheus_wireguard_exporter/issues/2).