### PR TITLE
Dockerize the app!

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+extra
+_config.yml
+.gitignore
+example.json
+LICENSE
+README.md
+/target
+**/*.rs.bk
+*.vim

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,9 @@
 .github
 extra
 _config.yml
+.dockerignore
 .gitignore
+Dockerfile
 example.json
 LICENSE
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG ALPINE_VERSION=3.12
+ARG RUST_VERSION=1-alpine${ALPINE_VERSION}
+
+FROM rust:${RUST_VERSION} AS build
+WORKDIR /usr/src/prometheus_wireguard_exporter
+
+# Setup
+ARG ARCH=x86_64
+RUN apk add --update -q --no-cache musl-dev
+RUN rustup target add ${ARCH}-unknown-linux-musl
+
+# Install dependencies
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && \
+    echo "fn main() {}" > src/main.rs
+RUN cargo build --release && \
+    rm -rf target/release/deps/prometheus_wireguard_exporter*
+
+# Build the musl linked binary
+COPY . .
+RUN cargo build --release
+RUN cargo install --target ${ARCH}-unknown-linux-musl --path .
+
+FROM alpine:${ALPINE_VERSION}
+EXPOSE 9586/tcp
+RUN apk add --update -q --no-cache wireguard-tools-wg
+COPY --from=build --chown=1000 /usr/local/cargo/bin/prometheus_wireguard_exporter /usr/local/bin/prometheus_wireguard_exporter
+ENTRYPOINT [ "prometheus_wireguard_exporter" ]
+CMD [ "-h" ]
+USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,5 @@ RUN cargo install --target ${ARCH}-unknown-linux-musl --path .
 FROM alpine:${ALPINE_VERSION}
 EXPOSE 9586/tcp
 RUN apk add --update -q --no-cache wireguard-tools-wg
-COPY --from=build --chown=1000 /usr/local/cargo/bin/prometheus_wireguard_exporter /usr/local/bin/prometheus_wireguard_exporter
+COPY --from=build /usr/local/cargo/bin/prometheus_wireguard_exporter /usr/local/bin/prometheus_wireguard_exporter
 ENTRYPOINT [ "prometheus_wireguard_exporter" ]
-CMD [ "-h" ]
-USER 1000

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ A Prometheus exporter for [WireGuard](https://www.wireguard.com), written in Rus
 * You need [Rust](https://www.rust-lang.org/) to compile this code. Simply follow the instructions on Rust's website to install the toolchain. If you get weird errors while compiling please try and update your Rust version first (I have developed it on `rustc 1.42.0 (b8cedc004 2020-03-09)`).
 * You need [WireGuard](https://www.wireguard.com) *and* the `wg` CLI in the path. The tool will call `wg show <interface(s)>|all dump` and of course will fail if the `wg` executable is not found. If you want I can add the option of specifying the `wg` path in the command line, just open an issue for it.
 
+Alternatively, as long as you have Wireguard on your host kernel with some Wireguard interfaces running, you can use Docker. For example:
+
+```sh
+docker build -t prometheusWireguardExporter https://github.com/mindflavor/prometheus_wireguard_exporter
+docker run -it --rm --init --net=host --cap-add=NET_ADMIN prometheusWireguardExporter
+# Check it's up
+docker run -it --rm alpine:3.12 wget -qO- http://localhost:9586/metrics
+```
+
 ## Compilation
 
 To compile the latest master version:


### PR DESCRIPTION
- Dockerfile + .dockerignore added, with a final 20MB Docker image
- Readme instructions on how to build'n'run

I'm a bit of a Docker maniac and like to run everything in containers (even iptables, not kidding!)

There are just 3 points we should address:

1. Maybe we can move that Docker section somewhere else in the readme
1. Do you have a Docker Hub account? If so, I can set up some Docker build pipeline with Github Actions so users can just pull the image, as building it is time consuming. It might even be possible to compile for all CPU architectures too (i.e. ARM etc.).
1. I noticed the program won't exit on CTRL-C at least in the container (tested on 2 machines). Is there a reason that comes to your mind? Using the Docker `--init` flag allows it to quit gracefully though, but it would be nice not to need it.

Anyway thanks for the great tool 👍 