### PR TITLE
Docker CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Docker build
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - .github/workflows/buildx-branch.yml
+      - .github/workflows/buildx-latest.yml
+      - .github/workflows/buildx-release.yml
+      - .github/workflows/dockerhub-description.yml
+      - .github/workflows/rust.yml
+      - extra
+      - _config.yml
+      - .gitignore
+      - .rustfmt.toml
+      - .gitignore
+      - example.json
+      - LICENSE
+      - README.md
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build image
+        run: docker build .

--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -1,0 +1,42 @@
+name: Buildx branch
+on:
+  push:
+    branches:
+      - '*'
+      - '*/*'
+      - '!master'
+    paths-ignore:
+      - .github/workflows/build.yml
+      - .github/workflows/buildx-latest.yml
+      - .github/workflows/buildx-release.yml
+      - .github/workflows/dockerhub-description.yml
+      - .github/workflows/rust.yml
+      - extra
+      - _config.yml
+      - .gitignore
+      - .rustfmt.toml
+      - .gitignore
+      - example.json
+      - LICENSE
+      - README.md
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Buildx setup
+        uses: crazy-max/ghaction-docker-buildx@v1
+      - name: Dockerhub login
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u mindflavor --password-stdin 2>&1
+      - name: Run Buildx
+        run: |
+          docker buildx build \
+            --progress plain \
+            --platform=linux/amd64,linux/386 \
+            --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+            --build-arg COMMIT=`git rev-parse --short HEAD` \
+            --build-arg VERSION=${GITHUB_REF##*/} \
+            -t mindflavor/prometheus-wireguard-exporter:${GITHUB_REF##*/} \
+            --push \
+            .
+      - run: curl -X POST https://hooks.microbadger.com/images/mindflavor/prometheus-wireguard-exporter/TODO || exit 0

--- a/.github/workflows/buildx-latest.yml
+++ b/.github/workflows/buildx-latest.yml
@@ -1,0 +1,39 @@
+name: Buildx latest
+on:
+  release:
+    types: [published]
+    paths-ignore:
+      - .github/workflows/build.yml
+      - .github/workflows/buildx-branch.yml
+      - .github/workflows/buildx-release.yml
+      - .github/workflows/dockerhub-description.yml
+      - .github/workflows/rust.yml
+      - extra
+      - _config.yml
+      - .gitignore
+      - .rustfmt.toml
+      - .gitignore
+      - example.json
+      - LICENSE
+      - README.md
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Buildx setup
+        uses: crazy-max/ghaction-docker-buildx@v1
+      - name: Dockerhub login
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u mindflavor --password-stdin 2>&1
+      - name: Run Buildx
+        run: |
+          docker buildx build \
+            --progress plain \
+            --platform=linux/amd64,linux/386 \
+            --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+            --build-arg COMMIT=`git rev-parse --short HEAD` \
+            --build-arg VERSION=latest \
+            -t mindflavor/prometheus-wireguard-exporter:latest \
+            --push \
+            .
+      - run: curl -X POST https://hooks.microbadger.com/images/mindflavor/prometheus-wireguard-exporter/TODO || exit 0

--- a/.github/workflows/buildx-release.yml
+++ b/.github/workflows/buildx-release.yml
@@ -1,0 +1,39 @@
+name: Buildx release
+on:
+  release:
+    types: [published]
+    paths-ignore:
+      - .github/workflows/build.yml
+      - .github/workflows/buildx-branch.yml
+      - .github/workflows/buildx-latest.yml
+      - .github/workflows/dockerhub-description.yml
+      - .github/workflows/rust.yml
+      - extra
+      - _config.yml
+      - .gitignore
+      - .rustfmt.toml
+      - .gitignore
+      - example.json
+      - LICENSE
+      - README.md
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Buildx setup
+        uses: crazy-max/ghaction-docker-buildx@v1
+      - name: Dockerhub login
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u mindflavor --password-stdin 2>&1
+      - name: Run Buildx
+        run: |
+          docker buildx build \
+            --progress plain \
+            --platform=linux/amd64,linux/386 \
+            --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+            --build-arg COMMIT=`git rev-parse --short HEAD` \
+            --build-arg VERSION=${GITHUB_REF##*/} \
+            -t mindflavor/prometheus-wireguard-exporter:${GITHUB_REF##*/} \
+            --push \
+            .
+      - run: curl -X POST https://hooks.microbadger.com/images/mindflavor/prometheus-wireguard-exporter/TODO || exit 0

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,19 @@
+name: Docker Hub description
+on:
+  push:
+    branches: [master]
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: mindflavor
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: mindflavor/prometheus-wireguard-exporter


### PR DESCRIPTION
Refers to #40 

- Simple Docker build for PR to the master branch to verify the build passes
- Docker buildx (for amd64 and 386) with Docker tag `:latest` on changes to the master branch
- Docker buildx (for amd64 and 386) with Docker tag `:<tag name>` on Github releases & tags
- Docker buildx (for amd64 and 386) on branch pushes `:<branch-name>`

**What's left to do**

1. Confirm the Docker Hub username
1. Fix microbadger link once Docker image is up on Docker Hub
1. Add buildx and microbadger docker image badges to readme
1. Support ARM64 builds, not so trivial after all in Rust unfortunately.