### PR TITLE
Remove linux/386 platform from buildx

### DIFF
--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/386 \
+            --platform=linux/amd64 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/.github/workflows/buildx-latest.yml
+++ b/.github/workflows/buildx-latest.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/386 \
+            --platform=linux/amd64 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=latest \

--- a/.github/workflows/buildx-release.yml
+++ b/.github/workflows/buildx-release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/386 \
+            --platform=linux/amd64 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \


### PR DESCRIPTION
In order for the Docker build to pass as only amd64 is supported for now.