### PR TITLE
Docker image without root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ RUN cargo install --target ${ARCH}-unknown-linux-musl --path .
 
 FROM alpine:${ALPINE_VERSION}
 EXPOSE 9586/tcp
-RUN apk add --update -q --no-cache wireguard-tools-wg
-COPY --from=build /usr/local/cargo/bin/prometheus_wireguard_exporter /usr/local/bin/prometheus_wireguard_exporter
+RUN adduser prometheus-wireguard-exporter -s /bin/sh -D -u 1000 1000 && \
+    mkdir -p /etc/sudoers.d && \
+    echo prometheus-wireguard-exporter ALL=\(root\) NOPASSWD:/usr/bin/wg show * dump > /etc/sudoers.d/prometheus-wireguard-exporter && \
+    chmod 0440 /etc/sudoers.d/prometheus-wireguard-exporter
+RUN apk add --update -q --no-cache wireguard-tools-wg sudo
+USER prometheus-wireguard-exporter
 ENTRYPOINT [ "prometheus_wireguard_exporter" ]
+CMD [ "-a" ]
+COPY --from=build --chown=prometheus-wireguard-exporter /usr/local/cargo/bin/prometheus_wireguard_exporter /usr/local/bin/prometheus_wireguard_exporter


### PR DESCRIPTION
Docker container runs with a non root user which has sudo access to run `wg` only.
Refers to #27 