### PR TITLE
Multi arch Dockerfile and CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,25 @@
+# This is used in the Docker build, you might need to adjust it for local usage.
+
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"
+
+[target.armv7-unknown-linux-musleabi]
+linker = "armv7m-linux-musleabi-gcc"
+
+[target.arm-unknown-linux-musleabi]
+linker = "armv6-linux-musleabi-gcc"
+
+[target.i686-unknown-linux-musl]
+linker = "i686-linux-musl-gcc"
+
+[target.powerpc64le-unknown-linux-musl]
+linker = "powerpc64le-linux-musl-gcc"
+
+[target.s390x-unknown-linux-musl]
+linker = "s390x-linux-musl-gcc"
+
+[target.riscv64gc-unknown-linux-musl]
+linker = "riscv64-linux-musl-gcc"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7 \
+            --platform=linux/amd64 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
+            --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64 \
+            --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64 \
+            --platform=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/.github/workflows/buildx-latest.yml
+++ b/.github/workflows/buildx-latest.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
+            --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=latest \

--- a/.github/workflows/buildx-latest.yml
+++ b/.github/workflows/buildx-latest.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64 \
+            --platform=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=latest \

--- a/.github/workflows/buildx-release.yml
+++ b/.github/workflows/buildx-release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64 \
+            --platform=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/.github/workflows/buildx-release.yml
+++ b/.github/workflows/buildx-release.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker buildx build \
             --progress plain \
-            --platform=linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
+            --platform=linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7 \
             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
             --build-arg COMMIT=`git rev-parse --short HEAD` \
             --build-arg VERSION=${GITHUB_REF##*/} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,12 @@ COPY .cargo ./.cargo
 # Install dependencies
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && \
-    echo "fn main() {}" > src/main.rs
-RUN CC="$(cat /tmp/musl)-gcc" cargo build --target "$(cat /tmp/rusttarget)" --release && \
-    rm -rf target/release/deps/prometheus_wireguard_exporter*
+    echo 'fn main() {}' > src/main.rs && \
+    CC="$(cat /tmp/musl)-gcc" cargo build --target "$(cat /tmp/rusttarget)" --release
+RUN rm -r \
+    target/*-linux-*/release/deps/prometheus_wireguard_exporter* \
+    target/*-linux-*/release/prometheus_wireguard_exporter* \
+    src/main.rs
 
 # Build static binary with musl built-in
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ ARG RUST_VERSION=1-alpine${ALPINE_VERSION}
 FROM rust:${RUST_VERSION} AS build
 WORKDIR /usr/src/prometheus_wireguard_exporter
 
-# Setup
-RUN apk add musl-dev
-
 # Install dependencies
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN apt-get update -y && \
     # for verifying the binary properties
     file
 
+# Download dependencies
+RUN mkdir src && \
+    echo 'fn main() {}' > src/main.rs
+COPY Cargo.toml Cargo.lock ./
+RUN cargo fetch && \
+    rm src/main.rs
+
 ARG TARGETPLATFORM
 RUN echo "Setting variables for ${TARGETPLATFORM:=linux/amd64}" && \
     case "${TARGETPLATFORM}" in \
@@ -68,9 +75,7 @@ RUN rustup target add "$(cat /tmp/rusttarget)"
 COPY .cargo ./.cargo
 
 # Install dependencies
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && \
-    echo 'fn main() {}' > src/main.rs && \
+RUN echo 'fn main() {}' > src/main.rs && \
     CC="$(cat /tmp/musl)-gcc" cargo build --target "$(cat /tmp/rusttarget)" --release
 RUN rm -r \
     target/*-linux-*/release/deps/prometheus_wireguard_exporter* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,99 @@
-ARG ALPINE_VERSION=3.12
-ARG RUST_VERSION=1-alpine${ALPINE_VERSION}
+ARG BUILDPLATFORM=linux/amd64
 
-FROM rust:${RUST_VERSION} AS build
+ARG ALPINE_VERSION=3.12
+ARG RUST_VERSION=1-slim-bullseye
+
+FROM --platform=${BUILDPLATFORM} rust:${RUST_VERSION} AS build
 WORKDIR /usr/src/prometheus_wireguard_exporter
+
+# Setup
+RUN apt-get update -y && \
+    apt-get install -y \
+    # to cross build with musl
+    musl-tools \
+    # to download the musl cross build tool
+    wget \
+    # for verifying the binary properties
+    file
+
+ARG TARGETPLATFORM
+RUN echo "Setting variables for ${TARGETPLATFORM}" && \
+    case "${TARGETPLATFORM}" in \
+      linux/amd64) \
+        MUSL="x86_64-linux-musl"; \
+        RUSTTARGET="x86_64-unknown-linux-musl"; \
+        break;; \
+      linux/arm64) \
+        MUSL="aarch64-linux-musl"; \
+        RUSTTARGET="aarch64-unknown-linux-musl"; \
+        break;; \
+      linux/arm/v7) \
+        MUSL="armv7m-linux-musleabi"; \
+        RUSTTARGET="armv7-unknown-linux-musleabi"; \
+        break;; \
+      linux/arm/v6) \
+        MUSL="armv6-linux-musleabi"; \
+        RUSTTARGET="arm-unknown-linux-musleabi"; \
+        break;; \
+      linux/386) \
+        MUSL="i686-linux-musl"; \
+        RUSTTARGET="i686-unknown-linux-musl"; \
+        break;; \
+      linux/ppc64le) \
+        MUSL="powerpc64le-linux-musl"; \
+        RUSTTARGET="powerpc64le-unknown-linux-musl"; \
+        break;; \
+      linux/s390x) \
+        MUSL="s390x-linux-musl"; \
+        RUSTTARGET="s390x-unknown-linux-musl"; \
+        break;; \
+      linux/riscv64) \
+        MUSL="riscv64-linux-musl"; \
+        RUSTTARGET="riscv64gc-unknown-linux-musl"; \
+        break;; \
+      *) echo "unsupported platform ${TARGETPLATFORM}"; exit 1;; \
+    esac && \
+    echo "${MUSL}" | tee /tmp/musl && \
+    echo "${RUSTTARGET}" | tee /tmp/rusttarget
+
+RUN MUSL="$(cat /tmp/musl)" && \
+    wget -qO- "https://musl.cc/$MUSL-cross.tgz" | tar -xzC /tmp && \
+    rm "/tmp/$MUSL-cross/usr" && \
+    cp -fr /tmp/"$MUSL"-cross/* / && \
+    rm -rf "/tmp/$MUSL-cross"
+
+RUN rustup target add "$(cat /tmp/rusttarget)"
+
+# Copy .cargo/config for cross build configuration
+COPY .cargo ./.cargo
 
 # Install dependencies
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && \
     echo "fn main() {}" > src/main.rs
-RUN cargo build --release && \
+RUN CC="$(cat /tmp/musl)-gcc" cargo build --target "$(cat /tmp/rusttarget)" --release && \
     rm -rf target/release/deps/prometheus_wireguard_exporter*
 
-# Build static binary
+# Build static binary with musl built-in
 COPY . .
-RUN cargo build --release && \
-    mv target/release/prometheus_wireguard_exporter /tmp/prometheus_wireguard_exporter
+RUN CC="$(cat /tmp/musl)-gcc" cargo build --target "$(cat /tmp/rusttarget)" --release && \
+    mv target/*-linux-*/release/prometheus_wireguard_exporter /tmp/binary
+RUN file /tmp/binary
+
+# Test the binary works on the target platform
+FROM scratch AS binarytest
+COPY --from=build /tmp/binary /binary
+RUN ["/binary", "--help"]
 
 FROM alpine:${ALPINE_VERSION}
 EXPOSE 9586/tcp
+WORKDIR /usr/local/bin
 RUN adduser prometheus-wireguard-exporter -s /bin/sh -D -u 1000 1000 && \
     mkdir -p /etc/sudoers.d && \
     echo 'prometheus-wireguard-exporter ALL=(root) NOPASSWD:/usr/bin/wg show * dump' > /etc/sudoers.d/prometheus-wireguard-exporter && \
     chmod 0440 /etc/sudoers.d/prometheus-wireguard-exporter
 RUN apk add --update -q --no-cache wireguard-tools-wg sudo
 USER prometheus-wireguard-exporter
-ENTRYPOINT [ "prometheus_wireguard_exporter" ]
+ENTRYPOINT [ "/usr/local/bin/prometheus_wireguard_exporter" ]
 CMD [ "-a" ]
-COPY --from=build --chown=prometheus-wireguard-exporter /tmp/prometheus_wireguard_exporter /usr/local/bin/prometheus_wireguard_exporter
+COPY --from=binarytest --chown=prometheus-wireguard-exporter /binary ./prometheus_wireguard_exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -y && \
     file
 
 ARG TARGETPLATFORM
-RUN echo "Setting variables for ${TARGETPLATFORM}" && \
+RUN echo "Setting variables for ${TARGETPLATFORM:=linux/amd64}" && \
     case "${TARGETPLATFORM}" in \
       linux/amd64) \
         MUSL="x86_64-linux-musl"; \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ docker run -it --rm --init --net=host --cap-add=NET_ADMIN mindflavor/prometheus-
 docker run -it --rm alpine:3.12 wget -qO- http://localhost:9586/metrics
 ```
 
+ℹ️ The Docker image is compatible with `amd64`, `386`, `arm64`, `armv7` and `armv6` CPUs.
+
 ## Compilation
 
 To compile the latest master version:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ docker run -it --rm alpine:3.12 wget -qO- http://localhost:9586/metrics
 
 ℹ️ The Docker image is compatible with `amd64`, `386`, `arm64`, `armv7` and `armv6` CPUs.
 
+To update the image, you can use
+
+```sh
+docker pull mindflavor/prometheus_wireguard_exporter
+```
+
+You can also build it with:
+
+```sh
+docker build -t mindflavor/prometheus_wireguard_exporter https://github.com/MindFlavor/prometheus_wireguard_exporter.git
+```
+
 ## Compilation
 
 To compile the latest master version:


### PR DESCRIPTION
## Dockerfile changes

- Use Debian based `:1-bullseye-slim` Rust image for cross compilation instead of `:1-alpine3.13`, because:
    - it's 20MB smaller
    - Alpine `3.13` does not work well on 32 bit systems with an older libseccomp like on Raspberry Pis
    - it does not require to install musl cross building tools for the build platform so it's faster ⚡
    - it's available on more platforms than just `amd64` and `arm64` so users could build the image on their raspberry pis if they want to
- Cross compile on native build platform so it's faster than Docker QEMU emulation ⚡
- Compile static binaries by bundling musl in the binary (as before, note that this uses +3MB)
- Set variables correctly for all Docker supported platforms
    - `ppc64le`, `s390x` and `riscv64` do not support the Rust standard lib so it will fail for these
    - Persist target platform variables through files in `/tmp/`
- Define linkers to use for each musl target in `.cargo/config`
- Cache dependencies properly for target platform (so it's fast ⚡ with 1s rebuilds 🎉)
- Scratch stage to test the binary is static and built correctly for the target platform
- Remove useless (and long) `cargo install` instruction ⚡
- Move statically compiled binary to `/tmp` to have a shorter `COPY` instruction for readability

## Github Actions

Github Actions workflows were changed to build for 386, arm64, armv6 and armv7 on top of amd64.

See #48 for an updated list of things left to do.

@MindFlavor feel free to ask questions/suggestions and approve the PR so we can finally have cross built Docker images 🎉 