### PR TITLE
CI fixes: dockerhub description and linting

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@2.4.2
+        uses: peter-evans/dockerhub-description@v2.4.3
         with:
           username: mindflavor
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ RUN rustup target add "$(cat /tmp/rusttarget)"
 # Copy .cargo/config for cross build configuration
 COPY .cargo ./.cargo
 
+# Install Clippy for build platform
+RUN rustup component add clippy
+
 # Install dependencies
 RUN echo 'fn main() {}' > src/main.rs && \
     RUSTFLAGS="$(cat /tmp/rustflags)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,7 @@ RUN rm -r \
 COPY . .
 
 FROM base AS lint
-ENTRYPOINT \
-    RUSTFLAGS="$(cat /tmp/rustflags)" \
+RUN RUSTFLAGS="$(cat /tmp/rustflags)" \
     CC="$(cat /tmp/musl)-gcc" \
     cargo clippy --target "$(cat /tmp/rusttarget)"
 


### PR DESCRIPTION
- Fix and upgrade: pin peter-evans/dockerhub-description to `v2.4.3` instead of `2.4.2`
- Fix lint Dockerfile target not running
- Fix build platform clippy installation