### PR TITLE
try to fix binary release: move freebsd config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,6 +23,3 @@ linker = "s390x-linux-musl-gcc"
 
 [target.riscv64gc-unknown-linux-musl]
 linker = "riscv64-linux-musl-gcc"
-
-[target.x86_64-unknown-freebsd]
-image = "docker.io/rustembedded/cross:x86_64-unknown-freebsd"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+# This is used in the Docker build, you might need to adjust it for local usage.
+
+[target.x86_64-unknown-freebsd]
+image = "svenstaro/cross-x86_64-unknown-freebsd:latest"


### PR DESCRIPTION
It seems that the freebsd target needs special handling and also another config location. I think it is working with my fix, as you can see at [the CI pipeline of my fork](https://github.com/tobikris/prometheus_wireguard_exporter/actions/runs/1973360893).

Fixes #59.