### PR TITLE
Add systemd-networkd peer syntax

### DIFF
--- a/src/wireguard_config.rs
+++ b/src/wireguard_config.rs
@@ -124,7 +124,7 @@ pub(crate) fn peer_entry_hashmap_try_from(
                 cur_block = None;
             }
 
-            if line == "[Peer]" {
+            if line == "[Peer]" || line == "[WireGuardPeer]" {
                 // start a new block
                 cur_block = Some(Vec::new());
             }


### PR DESCRIPTION
Systemd-networkd managed wireguard interfaces use ``[WireGuardPeer]`` rather than ``[Peer]``.

Friendly names need a peer section in config file. This change allow using both wireguard config files and systemd-networkd config files.