### PR TITLE
Update README docker repo typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Coming soon, subcribe to [#59](https://github.com/MindFlavor/prometheus_wireguar
 You can then update the image with
 
 ```sh
-docker pull mindflavor/prometheus_wireguard_exporter
+docker pull mindflavor/prometheus-wireguard-exporter
 ```
 
 Or use a [tagged image](https://hub.docker.com/r/mindflavor/prometheus-wireguard-exporter/tags) such as `:3.5.1`.


### PR DESCRIPTION
Git repo uses underscores, docker repo uses hyphens. Looks like things got a little mixed up here.

Confirmed that https://hub.docker.com/r/mindflavor/prometheus_wireguard_exporter/tags does not exist either