### PR TITLE
Fix binary releases, add RC service example

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,3 +23,6 @@ linker = "s390x-linux-musl-gcc"
 
 [target.riscv64gc-unknown-linux-musl]
 linker = "riscv64-linux-musl-gcc"
+
+[target.x86_64-unknown-freebsd]
+linker = "x86_64-unknown-freebsd"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
-    tags: [ '*' ]
+    paths:
+      - .github/workflows/binaries.yml
+      - src/**
+      - Cargo.lock
+      - Cargo.toml
   pull_request:
+    paths:
+      - .github/workflows/binaries.yml
+      - src/**
+      - Cargo.lock
+      - Cargo.toml
 
 jobs:
   build:
@@ -27,7 +35,7 @@ jobs:
           # - aarch64-unknown-freebsd <- std not precompiled
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -35,7 +43,19 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - run: cargo install cross --git https://github.com/cross-rs/cross # cross in crates.io is too old
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
+
+      - run: cargo install cross
 
       - name: Build
         continue-on-error: ${{ matrix.channel != 'stable' }}
@@ -50,7 +70,7 @@ jobs:
           name: prometheus_wireguard_exporter_${{ matrix.target }}
           path: prometheus_wireguard_exporter_${{ matrix.target }}
 
-      - uses: alexellis/upload-assets@0.3.0
+      - uses: alexellis/upload-assets@0.4.0
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - run: cargo install --git https://github.com/cross-rs/cross.git # cross in crates.io is too old
+      - run: cargo install cross --git https://github.com/cross-rs/cross # cross in crates.io is too old
 
       - name: Build
         continue-on-error: ${{ matrix.channel != 'stable' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Publish Binaries
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Test
+name: Build and Publish Docker Container
 on:
   push:
     paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Docker Test
 on:
   push:
     paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
 
       - name: Lint
         run: docker build --target lint .
@@ -44,12 +44,12 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v1.9.0
+      - uses: docker/login-action@v3
         with:
           username: mindflavor
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -73,7 +73,7 @@ jobs:
           fi
 
       - name: Build and push final image
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v5
         with:
           platforms: ${{ steps.vars.outputs.platforms }}
           build-args: |

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
+
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2.4.3
+        uses: peter-evans/dockerhub-description@v3
         with:
           username: mindflavor
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 ARG ALPINE_VERSION=3.14
-ARG RUST_VERSION=latest
+ARG RUST_VERSION=1.69-bullseye
 
 FROM --platform=${BUILDPLATFORM} rust:${RUST_VERSION} AS base
 WORKDIR /usr/src/prometheus_wireguard_exporter

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ systemd-analyze security prometheus-wireguard-exporter.service
 
 This example is for an installation on OPNsense.
 
-Add service user: `pw adduser wireguard_exporter -g wheel -d /nonexistent -s /usr/sbin/nologin -c "Prometheus wireguard_exporter user"`  
+Add service user: `pw adduser wireguard_exporter -u 518 -g wheel -d /nonexistent -s /usr/sbin/nologin -c "Prometheus wireguard_exporter user"`  
 Group `wheel` is nessesary to read the `wg*.conf` files.
 
 Service: `/usr/local/etc/rc.d/wireguard_exporter`

--- a/README.md
+++ b/README.md
@@ -322,6 +322,102 @@ If you're interested in more hardening, you can analyze the unit with:
 systemd-analyze security prometheus-wireguard-exporter.service
 ```
 
+### RC service file
+
+This example is for an installation on OPNsense.
+
+Add service user: `pw adduser wireguard_exporter -g wheel -d /nonexistent -s /usr/sbin/nologin -c "Prometheus wireguard_exporter user"`  
+Group `wheel` is nessesary to read the `wg*.conf` files.
+
+Service: `/usr/local/etc/rc.d/wireguard_exporter`
+```
+#!/bin/sh
+
+# PROVIDE: wireguard_exporter
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# Add the following lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# wireguard_exporter_enable (bool):          Set to NO by default.
+#               Set it to YES to enable wireguard_exporter.
+# wireguard_exporter_user (string):          Set user that wireguard_exporter will run under
+#               Default is "wireguard_exporter".
+# wireguard_exporter_group (string):         Set group that wireguard_exporter will run under
+#               Default is "wheel".
+# wireguard_exporter_args (string):          Set extra arguments to pass to wireguard_exporter
+#               Default is "".
+# wireguard_exporter_listen_address (string):Set ip that wireguard_exporter will listen on
+#               Default is "0.0.0.0".
+# wireguard_exporter_listen_port (integer):  Set port that wireguard_exporter will listen on
+#               Default is "9586".
+# node_exporter_configs (string):  Set directory that wireguard_exporter will watch
+#               Default is "/usr/local/etc/wireguard/*.conf".
+
+. /etc/rc.subr
+
+name=wireguard_exporter
+rcvar=wireguard_exporter_enable
+
+load_rc_config $name
+
+: ${wireguard_exporter_enable:="NO"}
+: ${wireguard_exporter_user:="wireguard_exporter"}
+: ${wireguard_exporter_group:="wheel"}
+: ${wireguard_exporter_args:=""}
+: ${wireguard_exporter_listen_address:="0.0.0.0"}
+: ${wireguard_exporter_listen_port:="9586"}
+: ${node_exporter_configs:="/usr/local/etc/wireguard/*.conf"}
+
+pidfile=/var/run/wireguard_exporter.pid
+command="/usr/sbin/daemon"
+procname="/usr/local/bin/wireguard_exporter"
+command_args="-f -p ${pidfile} -T ${name} \
+    /usr/bin/env ${procname} \
+    -l ${wireguard_exporter_listen_address} \
+	-p ${wireguard_exporter_listen_port} \
+    -n ${node_exporter_configs} \
+    ${wireguard_exporter_args}"
+
+start_precmd=wireguard_exporter_startprecmd
+
+wireguard_exporter_startprecmd()
+{
+    if [ ! -e ${pidfile} ]; then
+        install \
+            -o ${wireguard_exporter_user} \
+            -g ${wireguard_exporter_group} \
+            /dev/null ${pidfile};
+    fi
+}
+
+load_rc_config $name
+run_rc_command "$1"
+```
+
+Service configuration `/etc/rc.conf.d/wireguard_exporter`
+```
+wireguard_exporter_args="-a true -r true -d true "  # adjust to your liking
+wireguard_exporter_listen_address="172.16.0.1"      # listen address
+wireguard_exporter_enable="YES"                     # enable startup on boot
+```
+
+With the above unit, you can use the following sudo rule:
+
+```
+wireguard_exporter ALL=(root) NOPASSWD: /usr/bin/wg  # no sudo password required
+Cmnd_Alias WGEXPORT = /usr/bin/wg                    # configuration alias for further use
+Defaults!WGEXPORT !log_allowed                       # prevent logging of permitted executions
+```
+
+Testing
+
+```
+service wireguard_exporter stop
+sudo su -m wireguard_exporter -c '/usr/local/bin/wireguard_exporter -l 0.0.0.0 -p 9586 -n /usr/local/etc/wireguard/*.conf -a true -r true -d true'
+```
+
 ## Development
 
 ### Locally


### PR DESCRIPTION
- fix cross install for build
- fix freebsd build
- fix automated binary release
- add RC service example (OPNsense) to README.MD

~I have no clue how GitHub actions work and how i could make a release in my fork.
But the artifacts are there and working (at least FreeBSD).~

fixes https://github.com/MindFlavor/prometheus_wireguard_exporter/issues/59
closes https://github.com/MindFlavor/prometheus_wireguard_exporter/pull/91
resolves https://github.com/MindFlavor/prometheus_wireguard_exporter/pull/117
resolves https://github.com/MindFlavor/prometheus_wireguard_exporter/pull/118
resolves https://github.com/MindFlavor/prometheus_wireguard_exporter/pull/119

p.s.: I still have no clue about github actions. but it works :)
see https://github.com/Kariton/prometheus_wireguard_exporter/releases/tag/v3.6.6