### PR TITLE
Fix ci publishing binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -34,15 +34,15 @@ jobs:
           # - aarch64-unknown-freebsd <- std not precompiled
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.0
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: ${{ matrix.channel }}
           target: ${{ matrix.target }}
           override: true
 
-      - run: cargo install --git https://github.com/cross-rs/cross.git # cross in crates.io is too old
+      - run: cargo install cross
 
       - name: Build
         continue-on-error: ${{ matrix.channel != 'stable' }}
@@ -51,13 +51,13 @@ jobs:
       - name: Rename binary
         run: mv target/${{ matrix.target }}/release/prometheus_wireguard_exporter prometheus_wireguard_exporter_${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3.1.3
         if: ${{ matrix.channel == 'stable' }}
         with:
           name: prometheus_wireguard_exporter_${{ matrix.target }}
           path: prometheus_wireguard_exporter_${{ matrix.target }}
 
-      - uses: alexellis/upload-assets@0.3.0
+      - uses: alexellis/upload-assets@0.4.0
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,10 +1,17 @@
-name: CI
-
+name: build-and-publish-binaries
 on:
   push:
-    branches: [ master ]
-    tags: [ '*' ]
+    paths:
+      - .github/workflows/binaries.yml
+      - src/**
+      - Cargo.lock
+      - Cargo.toml
   pull_request:
+    paths:
+      - .github/workflows/binaries.yml
+      - src/**
+      - Cargo.lock
+      - Cargo.toml
 
 jobs:
   build:


### PR DESCRIPTION
I would like to be able to get a built binary from this repo so I tried to get the CI that was introduced for that into a workable state. I'm unfamiliar with Rust and with Github Actions so any suggestions for improvement are welcome.