### PR TITLE
Support multiple peer files from environment variable

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -1,3 +1,5 @@
+use std::env;
+use std::path::PathBuf;
 use clap::parser::ValuesRef;
 
 #[derive(Debug, Clone)]
@@ -18,8 +20,13 @@ impl Options {
             prepend_sudo: *matches.get_one("prepend_sudo").unwrap_or(&false),
             separate_allowed_ips: *matches.get_one("separate_allowed_ips").unwrap_or(&false),
             extract_names_config_files: matches
-                .get_many("extract_names_config_files")
-                .map(|e: ValuesRef<'_, String>| e.into_iter().map(|a| a.to_owned()).collect()),
+                .get_many::<String>("extract_names_config_files")
+                .map(|values_ref| {
+                    values_ref
+                        .flat_map(|s| env::split_paths(s))
+                        .map(|p: PathBuf| p.to_string_lossy().into_owned())
+                        .collect::<Vec<String>>()
+                }),
             interfaces: matches
                 .get_many("interfaces")
                 .map(|e: ValuesRef<'_, String>| e.into_iter().map(|a| a.to_string()).collect()),


### PR DESCRIPTION
This change enables specifying multiple WireGuard configuration files for the extract_names_config_files option using the PROMETHEUS_WIREGUARD_EXPORTER_CONFIG_FILE_NAMES environment variable.

It utilizes std::env::split_paths to automatically handle the correct OS-specific path list separator (: for Linux/Unix, ; for Windows).

Example (Environment Variable):
```
PROMETHEUS_WIREGUARD_EXPORTER_CONFIG_FILE_NAMES="/tmp/wg1/conf:/tmp/wg2.conf" prometheus_wireguard_exporter
```

This correctly parses as:
```
[INFO] using options: Options { extract_names_config_files: Some(["/tmp/wg1/conf", "/tmp/wg2.conf"]) }
```

This complements the existing command-line functionality:
```
prometheus_wireguard_exporter -n /tmp/wg1/conf /tmp/wg2.conf
```

Which also parses as:
```
[INFO] using options: Options { extract_names_config_files: Some(["/tmp/wg1/conf", "/tmp/wg2.conf"]) }
```


